### PR TITLE
Add Next.js dashboard for arbitrage spreads

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,24 @@ Tech stack: **Python 3.11 / FastAPI** (backend), **TypeScript / Next.js** (front
 
 ## Structure
 - `backend/` — FastAPI service, business logic and integrations.
-- `frontend/` — Next.js app (will be added in later steps).
+- `frontend/` — Next.js app (dashboard for spreads, see below).
 - `docs/` — Architecture, decisions, and runbooks.
 - `scripts/` — Utility scripts.
 - `.github/workflows/` — CI configs.
 
 ## Quickstart
 See `docs/02-setup.md` for environment setup and `docs/03-backend-dev.md` to run the API locally.
+
+## Frontend
+
+The `frontend` directory contains a Next.js 14 dashboard that consumes the deployed FastAPI
+service. To run it locally:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+By default the UI connects to `http://localhost:8000`. Override the API URL by setting the
+`NEXT_PUBLIC_API_BASE_URL` environment variable before starting the dev server.

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["next", "next/core-web-vitals"],
+  "rules": {
+    "react/jsx-props-no-spreading": "off"
+  }
+}

--- a/frontend/app/components/dashboard.tsx
+++ b/frontend/app/components/dashboard.tsx
@@ -1,0 +1,604 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import {
+  usePairLimits,
+  usePairOverview,
+  usePairRealtime,
+  usePairSpreads,
+  useStats,
+} from '../../lib/api';
+import { getWsBaseUrl } from '../../lib/config';
+import type {
+  ApiStats,
+  PairSelection,
+  SpreadCandle,
+  SpreadRow,
+} from '../../lib/types';
+
+interface DashboardProps {
+  initialStats: ApiStats | null;
+}
+
+const formatPercent = (value: number | null | undefined, digits = 2) => {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return '—';
+  }
+  return `${value.toFixed(digits)}%`;
+};
+
+const formatNumber = (value: number | null | undefined, digits = 2) => {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return '—';
+  }
+  return value.toLocaleString('en-US', {
+    maximumFractionDigits: digits,
+    minimumFractionDigits: digits,
+  });
+};
+
+const formatTimestamp = (ts?: number | null) => {
+  if (!ts) {
+    return '—';
+  }
+  const date = new Date(ts * 1000);
+  return date.toLocaleTimeString('ru-RU', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+};
+
+const TIMEFRAMES = ['1m', '5m', '1h'] as const;
+const LOOKBACK_OPTIONS: Array<{ label: string; value: number }> = [
+  { label: '24 часа', value: 1 },
+  { label: '7 дней', value: 7 },
+  { label: '30 дней', value: 30 },
+];
+
+type Metric = 'entry' | 'exit';
+
+function HistoryStats({ candles }: { candles: SpreadCandle[] }) {
+  const values = useMemo(() => candles.map((c) => c.close), [candles]);
+  const latest = values.at(-1);
+  const max = values.length ? Math.max(...values) : null;
+  const min = values.length ? Math.min(...values) : null;
+  const avg =
+    values.length && values.every((v) => Number.isFinite(v))
+      ? values.reduce((acc, v) => acc + v, 0) / values.length
+      : null;
+  return (
+    <div className="history-grid">
+      <div>
+        <div className="label">Последнее</div>
+        <div className="value accent">{formatPercent(latest)}</div>
+      </div>
+      <div>
+        <div className="label">Максимум</div>
+        <div className="value">{formatPercent(max)}</div>
+      </div>
+      <div>
+        <div className="label">Минимум</div>
+        <div className="value">{formatPercent(min)}</div>
+      </div>
+      <div>
+        <div className="label">Среднее</div>
+        <div className="value">{formatPercent(avg)}</div>
+      </div>
+    </div>
+  );
+}
+
+function HistoryPreview({ candles }: { candles: SpreadCandle[] }) {
+  const points = useMemo(() => {
+    if (!candles.length) {
+      return '';
+    }
+    const values = candles.map((c) => c.close);
+    const max = Math.max(...values);
+    const min = Math.min(...values);
+    const range = max - min || 1;
+    return values
+      .map((value, index) => {
+        const x = (index / Math.max(values.length - 1, 1)) * 100;
+        const y = 100 - ((value - min) / range) * 100;
+        return `${x},${y}`;
+      })
+      .join(' ');
+  }, [candles]);
+
+  if (!points) {
+    return <div className="empty-history">Нет данных</div>;
+  }
+
+  return (
+    <svg className="history-chart" viewBox="0 0 100 100" preserveAspectRatio="none">
+      <defs>
+        <linearGradient id="historyGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+          <stop offset="0%" stopColor="rgba(56, 189, 248, 1)" />
+          <stop offset="100%" stopColor="rgba(168, 85, 247, 1)" />
+        </linearGradient>
+      </defs>
+      <polyline
+        fill="none"
+        stroke="url(#historyGradient)"
+        strokeWidth="3"
+        points={points}
+      />
+    </svg>
+  );
+}
+
+function SpreadTable({
+  rows,
+  onSelect,
+  selection,
+}: {
+  rows: SpreadRow[];
+  onSelect: (row: SpreadRow) => void;
+  selection: PairSelection | null;
+}) {
+  if (!rows.length) {
+    return (
+      <div className="card">
+        <div className="card-title">Потоки котировок</div>
+        <p className="muted">Ожидаем данные с сервера...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="card table-card">
+      <div className="card-title">Активные спреды</div>
+      <div className="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>Пара</th>
+              <th>Лонг</th>
+              <th>Шорт</th>
+              <th>Вход</th>
+              <th>Выход</th>
+              <th>Funding</th>
+              <th>Комиссия</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => {
+              const isSelected =
+                selection?.symbol === row.symbol &&
+                selection?.long_exchange === row.long_exchange &&
+                selection?.short_exchange === row.short_exchange;
+              return (
+                <tr
+                  key={`${row.symbol}-${row.long_exchange}-${row.short_exchange}`}
+                  className={isSelected ? 'selected' : ''}
+                  onClick={() => onSelect(row)}
+                >
+                  <td>
+                    <div className="symbol">{row.symbol}</div>
+                    <div className="muted small">
+                      ask {formatNumber(row.price_long_ask, 4)} / bid {formatNumber(row.price_short_bid, 4)}
+                    </div>
+                  </td>
+                  <td>{row.long_exchange.toUpperCase()}</td>
+                  <td>{row.short_exchange.toUpperCase()}</td>
+                  <td className="accent">{formatPercent(row.entry_pct)}</td>
+                  <td>{formatPercent(row.exit_pct)}</td>
+                  <td>{formatPercent(row.funding_spread, 4)}</td>
+                  <td>{formatPercent(row.commission_total_pct)}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function PairDetails({
+  selection,
+  overview,
+  realtimeRow,
+}: {
+  selection: PairSelection | null;
+  overview: SpreadRow | null;
+  realtimeRow: SpreadRow | null;
+}) {
+  if (!selection) {
+    return (
+      <div className="card">
+        <div className="card-title">Детали связки</div>
+        <p className="muted">Выберите связку из таблицы слева.</p>
+      </div>
+    );
+  }
+
+  const baseRow = realtimeRow ?? overview;
+
+  if (!baseRow) {
+    return (
+      <div className="card">
+        <div className="card-title">Детали связки</div>
+        <p className="muted">Нет данных по выбранной связке.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="card">
+      <div className="card-title">{selection.symbol}</div>
+      <div className="pair-grid">
+        <div>
+          <div className="label">Лонг</div>
+          <div className="value">{selection.long_exchange.toUpperCase()}</div>
+          <div className="muted small">
+            ask {formatNumber(baseRow.price_long_ask, 4)} / bid {formatNumber(baseRow.price_long_bid, 4)}
+          </div>
+        </div>
+        <div>
+          <div className="label">Шорт</div>
+          <div className="value">{selection.short_exchange.toUpperCase()}</div>
+          <div className="muted small">
+            ask {formatNumber(baseRow.price_short_ask, 4)} / bid {formatNumber(baseRow.price_short_bid, 4)}
+          </div>
+        </div>
+        <div>
+          <div className="label">Входной спред</div>
+          <div className="value accent">{formatPercent(baseRow.entry_pct)}</div>
+        </div>
+        <div>
+          <div className="label">Выходной спред</div>
+          <div className="value">{formatPercent(baseRow.exit_pct)}</div>
+        </div>
+        <div>
+          <div className="label">Funding лонга</div>
+          <div className="value">{formatPercent(baseRow.funding_long, 4)}</div>
+          <div className="muted small">интервал {baseRow.funding_interval_long || '—'}</div>
+        </div>
+        <div>
+          <div className="label">Funding шорта</div>
+          <div className="value">{formatPercent(baseRow.funding_short, 4)}</div>
+          <div className="muted small">интервал {baseRow.funding_interval_short || '—'}</div>
+        </div>
+        <div>
+          <div className="label">Спред Funding</div>
+          <div className="value">{formatPercent(baseRow.funding_spread, 4)}</div>
+        </div>
+        <div>
+          <div className="label">Полный цикл</div>
+          <div className="value">{formatPercent(baseRow.commission_total_pct)}</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function LimitsCard({
+  selection,
+  limits,
+}: {
+  selection: PairSelection | null;
+  limits: ReturnType<typeof usePairLimits>['data'];
+}) {
+  if (!selection) {
+    return null;
+  }
+
+  const longLimit = limits?.long as Record<string, unknown> | null | undefined;
+  const shortLimit = limits?.short as Record<string, unknown> | null | undefined;
+
+  const renderLimit = (limit: Record<string, unknown> | null | undefined) => {
+    if (!limit) {
+      return <p className="muted small">Нет данных</p>;
+    }
+
+    const entries: ReactNode[] = [];
+    const maxQtyRaw = limit['max_qty'];
+    if (maxQtyRaw !== undefined) {
+      const maxQty = Number(maxQtyRaw);
+      if (!Number.isNaN(maxQty) && maxQty > 0) {
+        entries.push(<li key="qty">Макс. объём: {formatNumber(maxQty, 2)}</li>);
+      }
+    }
+
+    const maxNotionalRaw = limit['max_notional'];
+    if (maxNotionalRaw !== undefined) {
+      const maxNotional = Number(maxNotionalRaw);
+      if (!Number.isNaN(maxNotional) && maxNotional > 0) {
+        entries.push(
+          <li key="notional">Макс. нотионал: {formatNumber(maxNotional, 2)}</li>,
+        );
+      }
+    }
+
+    const limitDescRaw = limit['limit_desc'];
+    if (limitDescRaw) {
+      entries.push(<li key="desc">{String(limitDescRaw)}</li>);
+    }
+
+    if (!entries.length) {
+      entries.push(<li key="empty">Нет данных</li>);
+    }
+
+    return <ul className="limits-list">{entries}</ul>;
+  };
+
+  return (
+    <div className="card">
+      <div className="card-title">Лимиты бирж</div>
+      <div className="limits-grid">
+        <div>
+          <div className="label">{selection.long_exchange.toUpperCase()}</div>
+          {renderLimit(longLimit)}
+        </div>
+        <div>
+          <div className="label">{selection.short_exchange.toUpperCase()}</div>
+          {renderLimit(shortLimit)}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function OverviewCard({ overview }: { overview: SpreadRow[] | undefined }) {
+  if (!overview?.length) {
+    return null;
+  }
+  return (
+    <div className="card">
+      <div className="card-title">Все комбинации</div>
+      <div className="chips">
+        {overview.map((row) => (
+          <span key={`${row.long_exchange}-${row.short_exchange}`} className="chip">
+            {row.long_exchange.toUpperCase()} → {row.short_exchange.toUpperCase()} ({formatPercent(row.entry_pct)})
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function Header({
+  stats,
+  wsStatus,
+  lastUpdated,
+}: {
+  stats: ApiStats | undefined;
+  wsStatus: string;
+  lastUpdated: number | null;
+}) {
+  return (
+    <header className="top-bar">
+      <div>
+        <h1>Arbitrage Scanner</h1>
+        <p className="muted">
+          {stats
+            ? `Биржи: ${stats.exchanges.join(', ')} • Подписок: ${stats.symbols_subscribed.length}`
+            : 'Не удалось получить статистику API'}
+        </p>
+      </div>
+      <div className="status">
+        <span className={`status-dot ${wsStatus}`}></span>
+        <span>{wsStatus === 'open' ? 'Данные обновляются' : wsStatus === 'connecting' ? 'Подключаемся…' : 'Нет соединения'}</span>
+        <span className="muted small">
+          {lastUpdated ? `Обновлено: ${new Date(lastUpdated).toLocaleTimeString('ru-RU')}` : ''}
+        </span>
+      </div>
+    </header>
+  );
+}
+
+export default function Dashboard({ initialStats }: DashboardProps) {
+  const { data: stats } = useStats(initialStats ?? undefined);
+  const [rows, setRows] = useState<SpreadRow[]>([]);
+  const [wsStatus, setWsStatus] = useState<'connecting' | 'open' | 'closed'>('connecting');
+  const [search, setSearch] = useState('');
+  const [selected, setSelected] = useState<PairSelection | null>(null);
+  const [timeframe, setTimeframe] = useState<(typeof TIMEFRAMES)[number]>('1m');
+  const [metric, setMetric] = useState<Metric>('entry');
+  const [lookbackDays, setLookbackDays] = useState<number>(7);
+  const [lastUpdated, setLastUpdated] = useState<number | null>(null);
+  const hasInitialSelection = useRef(false);
+
+  useEffect(() => {
+    const wsUrl = `${getWsBaseUrl()}/ws/spreads`;
+    let cancelled = false;
+    const ws = new WebSocket(wsUrl);
+    setWsStatus('connecting');
+
+    ws.onopen = () => {
+      if (!cancelled) {
+        setWsStatus('open');
+      }
+    };
+
+    ws.onclose = () => {
+      if (!cancelled) {
+        setWsStatus('closed');
+      }
+    };
+
+    ws.onerror = () => {
+      if (!cancelled) {
+        setWsStatus('closed');
+      }
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const payload = JSON.parse(event.data) as SpreadRow[];
+        if (!Array.isArray(payload)) {
+          return;
+        }
+        payload.sort((a, b) => b.entry_pct - a.entry_pct);
+        setRows(payload);
+        setLastUpdated(Date.now());
+        if (!hasInitialSelection.current && payload.length) {
+          const first = payload[0];
+          setSelected({
+            symbol: first.symbol,
+            long_exchange: first.long_exchange,
+            short_exchange: first.short_exchange,
+          });
+          hasInitialSelection.current = true;
+        }
+      } catch (error) {
+        console.warn('Failed to parse websocket payload', error);
+      }
+    };
+
+    return () => {
+      cancelled = true;
+      try {
+        ws.close();
+      } catch (error) {
+        // ignore
+      }
+    };
+  }, []);
+
+  const filteredRows = useMemo(() => {
+    const query = search.trim().toUpperCase();
+    if (!query) {
+      return rows.slice(0, 100);
+    }
+    return rows.filter((row) => row.symbol.toUpperCase().includes(query)).slice(0, 100);
+  }, [rows, search]);
+
+  const selection = selected;
+  const { data: overviewData } = usePairOverview(selection);
+  const { data: spreadsData } = usePairSpreads(selection, {
+    timeframe,
+    metric,
+    days: lookbackDays,
+  });
+  const { data: limitsData } = usePairLimits(selection);
+  const { data: realtimeData } = usePairRealtime(selection);
+
+  const realtimeRow = useMemo(() => {
+    if (realtimeData?.row) {
+      return realtimeData.row;
+    }
+    if (!selection) {
+      return null;
+    }
+    const fromStream = rows.find(
+      (row) =>
+        row.symbol === selection.symbol &&
+        row.long_exchange === selection.long_exchange &&
+        row.short_exchange === selection.short_exchange,
+    );
+    return fromStream ?? null;
+  }, [realtimeData, rows, selection]);
+
+  const overviewRow = useMemo(() => {
+    if (!selection) {
+      return null;
+    }
+    const rowsList = overviewData?.rows || [];
+    return (
+      rowsList.find(
+        (row) =>
+          row.long_exchange === selection.long_exchange &&
+          row.short_exchange === selection.short_exchange,
+      ) ?? null
+    );
+  }, [overviewData, selection]);
+
+  const historyCandles = spreadsData?.candles ?? [];
+
+  return (
+    <div className="container">
+      <Header stats={stats} wsStatus={wsStatus} lastUpdated={lastUpdated} />
+      <section className="content">
+        <div className="left-column">
+          <div className="card">
+            <div className="card-title">Фильтр</div>
+            <input
+              className="search-input"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Например, BTCUSDT"
+            />
+          </div>
+          <SpreadTable
+            rows={filteredRows}
+            selection={selection}
+            onSelect={(row) =>
+              setSelected({
+                symbol: row.symbol,
+                long_exchange: row.long_exchange,
+                short_exchange: row.short_exchange,
+              })
+            }
+          />
+        </div>
+        <div className="right-column">
+          <PairDetails selection={selection} overview={overviewRow} realtimeRow={realtimeRow} />
+
+          <div className="card">
+            <div className="card-title">История спреда</div>
+            <div className="controls">
+              <div className="control-group">
+                {TIMEFRAMES.map((tf) => (
+                  <button
+                    key={tf}
+                    className={tf === timeframe ? 'control active' : 'control'}
+                    onClick={() => setTimeframe(tf)}
+                  >
+                    {tf}
+                  </button>
+                ))}
+              </div>
+              <div className="control-group">
+                <button
+                  className={metric === 'entry' ? 'control active' : 'control'}
+                  onClick={() => setMetric('entry')}
+                >
+                  Вход
+                </button>
+                <button
+                  className={metric === 'exit' ? 'control active' : 'control'}
+                  onClick={() => setMetric('exit')}
+                >
+                  Выход
+                </button>
+              </div>
+              <div className="control-group">
+                {LOOKBACK_OPTIONS.map((option) => (
+                  <button
+                    key={option.value}
+                    className={lookbackDays === option.value ? 'control active' : 'control'}
+                    onClick={() => setLookbackDays(option.value)}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+            {selection ? (
+              historyCandles.length ? (
+                <>
+                  <HistoryPreview candles={historyCandles} />
+                  <HistoryStats candles={historyCandles} />
+                  <div className="muted small">
+                    Последнее обновление: {formatTimestamp(realtimeRow?._ts ?? realtimeData?.ts ?? null)}
+                  </div>
+                </>
+              ) : (
+                <p className="muted">Нет данных для выбранного набора параметров.</p>
+              )
+            ) : (
+              <p className="muted">Выберите связку для просмотра истории.</p>
+            )}
+          </div>
+
+          <LimitsCard selection={selection} limits={limitsData} />
+          <OverviewCard overview={overviewData?.rows} />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,0 +1,331 @@
+:root {
+  color-scheme: dark;
+  --bg-color: #0b1120;
+  --card-bg: #111c2e;
+  --card-border: #1f2a3f;
+  --text-primary: #f8fafc;
+  --text-secondary: #94a3b8;
+  --accent: #38bdf8;
+  --accent-muted: rgba(56, 189, 248, 0.15);
+  --danger: #f87171;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.12), transparent 35%),
+    radial-gradient(circle at bottom right, rgba(168, 85, 247, 0.08), transparent 45%),
+    var(--bg-color);
+  color: var(--text-primary);
+}
+
+main {
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.5);
+  border-radius: 5px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(148, 163, 184, 0.7);
+}
+
+.container {
+  width: min(1200px, 95%);
+  margin: 0 auto;
+  padding: 40px 0 60px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.top-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.top-bar h1 {
+  font-size: 28px;
+  margin: 0 0 6px;
+}
+
+.top-bar .status {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+  font-size: 14px;
+}
+
+.status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  display: inline-block;
+  margin-right: 6px;
+  background: var(--accent-muted);
+}
+
+.status-dot.open {
+  background: #4ade80;
+}
+
+.status-dot.connecting {
+  background: #facc15;
+}
+
+.status-dot.closed {
+  background: var(--danger);
+}
+
+.content {
+  display: grid;
+  grid-template-columns: 360px 1fr;
+  gap: 24px;
+}
+
+.left-column,
+.right-column {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  padding: 20px 24px;
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.25);
+  backdrop-filter: blur(8px);
+}
+
+.card-title {
+  font-weight: 600;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+
+.muted {
+  color: var(--text-secondary);
+}
+
+.small {
+  font-size: 12px;
+}
+
+.search-input {
+  width: 100%;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.7);
+  color: inherit;
+  font-size: 14px;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.8);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.15);
+}
+
+.table-card {
+  padding: 0;
+}
+
+.table-card .card-title {
+  padding: 20px 24px 0;
+  margin: 0;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  padding: 0 24px 20px;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+th,
+td {
+  padding: 12px 10px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+th {
+  text-align: left;
+  font-weight: 500;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 12px;
+}
+
+tr {
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+tr:hover {
+  background: rgba(56, 189, 248, 0.05);
+}
+
+tr.selected {
+  background: rgba(56, 189, 248, 0.12);
+}
+
+.symbol {
+  font-weight: 600;
+  font-size: 15px;
+  letter-spacing: 0.02em;
+}
+
+.pair-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.label {
+  font-size: 12px;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  letter-spacing: 0.08em;
+  margin-bottom: 6px;
+}
+
+.value {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.value.accent,
+.accent {
+  color: var(--accent);
+}
+
+.history-chart {
+  width: 100%;
+  height: 180px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.history-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 12px;
+  margin-top: 20px;
+}
+
+.empty-history {
+  padding: 32px;
+  text-align: center;
+  color: var(--text-secondary);
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 12px;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.control-group {
+  display: inline-flex;
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 10px;
+  padding: 4px;
+  gap: 6px;
+}
+
+.control {
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  padding: 8px 12px;
+  border-radius: 8px;
+  font-size: 13px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.control:hover {
+  color: var(--text-primary);
+}
+
+.control.active {
+  background: rgba(56, 189, 248, 0.15);
+  color: var(--accent);
+}
+
+.limits-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 16px;
+}
+
+.limits-list {
+  margin: 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 6px;
+  font-size: 13px;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.chip {
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.15);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 1024px) {
+  .content {
+    grid-template-columns: 1fr;
+  }
+
+  .left-column {
+    order: 2;
+  }
+
+  .right-column {
+    order: 1;
+  }
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'Arbitrage Scanner UI',
+  description:
+    'Визуализация крипто-спредов с серверного API arbitrage-scanner.',
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="ru">
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,0 +1,33 @@
+import Dashboard from './components/dashboard';
+import { getApiBaseUrl } from '../lib/config';
+import type { ApiStats } from '../lib/types';
+
+export const dynamic = 'force-dynamic';
+
+async function fetchStats(): Promise<ApiStats | null> {
+  const baseUrl = getApiBaseUrl();
+  try {
+    const response = await fetch(`${baseUrl}/stats`, {
+      cache: 'no-store',
+      next: { revalidate: 5 },
+    });
+    if (!response.ok) {
+      return null;
+    }
+    const payload = (await response.json()) as ApiStats;
+    return payload;
+  } catch (error) {
+    console.error('Failed to load /stats', error);
+    return null;
+  }
+}
+
+export default async function Page() {
+  const stats = await fetchStats();
+
+  return (
+    <Dashboard
+      initialStats={stats}
+    />
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,0 +1,71 @@
+'use client';
+
+import useSWR from 'swr';
+import { getApiBaseUrl } from './config';
+import type {
+  ApiStats,
+  PairLimitsResponse,
+  PairOverviewResponse,
+  PairSelection,
+  PairSpreadsResponse,
+  PairRealtimeResponse,
+} from './types';
+
+const fetcher = async <T>(url: string): Promise<T> => {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`);
+  }
+  return (await response.json()) as T;
+};
+
+export function usePairOverview(selection: PairSelection | null) {
+  const baseUrl = getApiBaseUrl();
+  const key = selection
+    ? `${baseUrl}/api/pair/${selection.symbol}/overview`
+    : null;
+  return useSWR<PairOverviewResponse>(key, fetcher, {
+    refreshInterval: 15_000,
+  });
+}
+
+export function usePairSpreads(
+  selection: PairSelection | null,
+  options: { timeframe: string; metric: 'entry' | 'exit'; days: number },
+) {
+  const baseUrl = getApiBaseUrl();
+  const key = selection
+    ? `${baseUrl}/api/pair/${selection.symbol}/spreads?long=${selection.long_exchange}&short=${selection.short_exchange}&timeframe=${options.timeframe}&metric=${options.metric}&days=${options.days}`
+    : null;
+  return useSWR<PairSpreadsResponse>(key, fetcher, {
+    refreshInterval: 60_000,
+  });
+}
+
+export function usePairLimits(selection: PairSelection | null) {
+  const baseUrl = getApiBaseUrl();
+  const key = selection
+    ? `${baseUrl}/api/pair/${selection.symbol}/limits?long=${selection.long_exchange}&short=${selection.short_exchange}`
+    : null;
+  return useSWR<PairLimitsResponse>(key, fetcher, {
+    refreshInterval: 300_000,
+  });
+}
+
+export function usePairRealtime(selection: PairSelection | null) {
+  const baseUrl = getApiBaseUrl();
+  const key = selection
+    ? `${baseUrl}/api/pair/${selection.symbol}/realtime?long=${selection.long_exchange}&short=${selection.short_exchange}`
+    : null;
+  return useSWR<PairRealtimeResponse>(key, fetcher, {
+    refreshInterval: 5_000,
+  });
+}
+
+export function useStats(initial?: ApiStats | null) {
+  const baseUrl = getApiBaseUrl();
+  return useSWR<ApiStats>(`${baseUrl}/stats`, fetcher, {
+    refreshInterval: 60_000,
+    fallbackData: initial ?? undefined,
+  });
+}

--- a/frontend/lib/config.ts
+++ b/frontend/lib/config.ts
@@ -1,0 +1,22 @@
+const DEFAULT_API_BASE_URL = 'http://localhost:8000';
+
+export function getApiBaseUrl(): string {
+  const fromEnv =
+    process.env.NEXT_PUBLIC_API_BASE_URL?.trim() ||
+    process.env.ARBITRAGE_API_BASE_URL?.trim();
+  if (fromEnv) {
+    return fromEnv.replace(/\/$/, '');
+  }
+  return DEFAULT_API_BASE_URL;
+}
+
+export function getWsBaseUrl(): string {
+  const httpUrl = getApiBaseUrl();
+  if (httpUrl.startsWith('https://')) {
+    return `wss://${httpUrl.slice('https://'.length)}`;
+  }
+  if (httpUrl.startsWith('http://')) {
+    return `ws://${httpUrl.slice('http://'.length)}`;
+  }
+  return httpUrl;
+}

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -1,0 +1,72 @@
+export interface ApiStats {
+  symbols_subscribed: string[];
+  tickers_in_store: number;
+  exchanges: string[];
+}
+
+export interface SpreadRow {
+  symbol: string;
+  long_exchange: string;
+  short_exchange: string;
+  entry_pct: number;
+  exit_pct: number;
+  funding_long: number;
+  funding_short: number;
+  funding_interval_long: string;
+  funding_interval_short: string;
+  funding_spread: number;
+  commission_total_pct: number;
+  commission: number;
+  price_long_ask: number;
+  price_short_bid: number;
+  price_long_bid: number;
+  price_short_ask: number;
+  orderbook_long?: unknown;
+  orderbook_short?: unknown;
+  _ts?: number;
+}
+
+export interface PairOverviewResponse {
+  symbol: string;
+  rows: SpreadRow[];
+}
+
+export interface SpreadCandle {
+  ts: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+}
+
+export interface PairSpreadsResponse {
+  symbol: string;
+  long: string;
+  short: string;
+  metric: 'entry' | 'exit';
+  timeframe: string;
+  timeframe_seconds: number;
+  candles: SpreadCandle[];
+}
+
+export interface PairLimitsResponse {
+  symbol: string;
+  long_exchange: string;
+  short_exchange: string;
+  long: Record<string, unknown> | null;
+  short: Record<string, unknown> | null;
+}
+
+export interface PairRealtimeResponse {
+  symbol: string;
+  long_exchange: string;
+  short_exchange: string;
+  ts: number;
+  row: SpreadRow | null;
+}
+
+export interface PairSelection {
+  symbol: string;
+  long_exchange: string;
+  short_exchange: string;
+}

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    optimizePackageImports: ['swr']
+  }
+};
+
+export default nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "arbitrage-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "swr": "2.2.4"
+  },
+  "devDependencies": {
+    "@types/node": "20.10.6",
+    "@types/react": "18.2.45",
+    "@types/react-dom": "18.2.17",
+    "eslint": "8.56.0",
+    "eslint-config-next": "14.1.0",
+    "typescript": "5.3.3"
+  }
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    },
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add a Next.js 14 frontend dashboard that streams live spreads and shows detailed pair metrics
- include shared API helpers, configuration, and styling for the new UI
- document how to run the frontend and configure the API endpoint in the README

## Testing
- npm install *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68e564f61a0c832d8208216371399816